### PR TITLE
Improving loading of overlay

### DIFF
--- a/src/app/components/ui/RecordDetails/RecordDetails.tsx
+++ b/src/app/components/ui/RecordDetails/RecordDetails.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { motion } from "framer-motion";
 import Record from "./Record";
 import Description from "./Description";
@@ -12,11 +11,13 @@ import { recordResultsList } from "@/app/utils/RecordResultsList";
 interface RecordDetailsProps {
   albumId: number;
   onClose: () => void;
+  albumCover?: React.ReactNode;
 }
 
 export default function RecordDetails({
   albumId,
   onClose,
+  albumCover,
 }: RecordDetailsProps) {
   const albumData = recordResultsList.find(
     (album) => album.id === albumId
@@ -44,17 +45,9 @@ export default function RecordDetails({
               innerColour={albumData.innerColour || ""}
               lineColour={albumData.recordLineColour || "white"}
             />
-            <motion.div
-              layoutId={`image-${albumData.imageString}`}
-              transition={{ duration: 0.3, bounce: 0, type: "spring" }}
-              className="size-[200px] lg:size-[320px] aspect-square absolute top-0 mr-[-120px] shadow-[4px_0_4px_0_rgba(0,0,0,0.25)]"
-            >
-              <Image
-                src={albumData.imageString}
-                alt={`${albumData.title} album cover`}
-                fill
-              />
-            </motion.div>
+            <div className="absolute top-0 mr-[-120px] size-[200px] lg:size-[320px] aspect-square shadow-[4px_0_4px_0_rgba(0,0,0,0.25)]">
+              {albumCover}
+            </div>
           </div>
           <Description
             artist={albumData.artist}

--- a/src/app/components/ui/RecordResult.tsx
+++ b/src/app/components/ui/RecordResult.tsx
@@ -2,13 +2,19 @@ import { motion } from "framer-motion";
 import Image from "next/image";
 import { RecordResultProps } from "../../utils/types";
 import useMeasure from "react-use-measure";
+import React from "react";
+
+interface RecordResultComponentProps extends RecordResultProps {
+  recordCover?: React.ReactNode;
+}
 
 export default function RecordResult({
   imageString,
   title,
   artist,
   year,
-}: RecordResultProps) {
+  recordCover,
+}: RecordResultComponentProps) {
   const [ref, bounds] = useMeasure();
 
   return (
@@ -33,19 +39,9 @@ export default function RecordResult({
               className="blur-[5px] opacity-10 z-0 max-w-full h-auto"
             />
           </div>
-          <motion.div
-            layoutId={`image-${imageString}`}
-            transition={{ duration: 0.3, bounce: 0, type: "spring" }}
-            className="md:size-[262px] sm:size-[162px] size-[148px] absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 aspect-square"
-          >
-            <Image
-              src={imageString}
-              alt={`${title} album cover`}
-              fill
-              sizes="(max-width: 768px) 148px, 262px"
-              className="z-10"
-            />
-          </motion.div>
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 md:size-[262px] sm:size-[162px] size-[148px] aspect-square">
+            {recordCover}
+          </div>
         </div>
         <div className="flex flex-col gap-1 md:gap-2 px-4">
           <h2 className="font-sans md:text-2xl text-xl font-semibold text-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { motion } from "framer-motion";
+import Image from "next/image";
 import DesktopMenu from "./components/ui/DesktopMenu";
 import MobileMenu from "./components/ui/MobileMenu";
 import RecordResult from "./components/ui/RecordResult";
@@ -9,6 +11,30 @@ import { MailIcon } from "./components/ui/Icons";
 import { Button } from "./components/ui/Button";
 import FilterBar from "./components/ui/FilterBar";
 import RecordDetails from "./components/ui/RecordDetails/RecordDetails";
+
+function RecordCover({
+  imageString,
+  title,
+}: {
+  imageString: string;
+  title: string;
+}) {
+  return (
+    <motion.div
+      layoutId={`image-${imageString}`}
+      transition={{ duration: 0.3, bounce: 0, type: "spring" }}
+      className="w-full h-full aspect-square"
+    >
+      <Image
+        src={imageString}
+        alt={`${title} album cover`}
+        fill
+        sizes="(max-width: 768px) 148px, 262px"
+        className="z-10"
+      />
+    </motion.div>
+  );
+}
 
 export default function Home() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -71,6 +97,20 @@ export default function Home() {
           <RecordDetails
             albumId={selectedAlbumId}
             onClose={() => setShowOverlay(false)}
+            albumCover={
+              <RecordCover
+                imageString={
+                  recordResultsList.find(
+                    (album) => album.id === selectedAlbumId
+                  )?.imageString || ""
+                }
+                title={
+                  recordResultsList.find(
+                    (album) => album.id === selectedAlbumId
+                  )?.title || ""
+                }
+              />
+            }
           />
         )}
         <div className="w-full max-w-[1360px] flex flex-col xl:gap-8 gap-4 h-full px-4 min-h-0">
@@ -119,6 +159,12 @@ export default function Home() {
                       title={record.title}
                       artist={record.artist}
                       year={record.year}
+                      recordCover={
+                        <RecordCover
+                          imageString={record.imageString}
+                          title={record.title}
+                        />
+                      }
                     />
                   </button>
                 ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ function RecordCover({
   return (
     <motion.div
       layoutId={`image-${imageString}`}
-      transition={{ duration: 0.3, bounce: 0, type: "spring" }}
+      transition={{ duration: 0.5, bounce: 0, type: "spring" }}
       className="w-full h-full aspect-square"
     >
       <Image


### PR DESCRIPTION
The record cover now longer unmounts and mounts when the overlay appears. Instead, the image is called on the main page and passed to the record details and result components.